### PR TITLE
Spaces

### DIFF
--- a/commando/respwriter.go
+++ b/commando/respwriter.go
@@ -156,7 +156,7 @@ func sanitizeFileName(s string) string {
 
 	s = r.Replace(s)
 
-	re := regexp.MustCompile(`[^0-9A-Za-z\s.\_\-]+`)
+	re := regexp.MustCompile(`[^0-9A-Za-z\\s.\_\-]+`)
 
 	return re.ReplaceAllString(s, "-")
 }

--- a/commando/respwriter.go
+++ b/commando/respwriter.go
@@ -155,6 +155,9 @@ func sanitizeFileName(s string) string {
 		`,`, ``)
 
 	s = r.Replace(s)
+	
+	// remove all leading and trailing spaces for the filename
+	s = strings.TrimSpace(s)
 
 	re := regexp.MustCompile(`[^0-9A-Za-z.\_\-]+`)
 

--- a/commando/respwriter.go
+++ b/commando/respwriter.go
@@ -156,7 +156,7 @@ func sanitizeFileName(s string) string {
 
 	s = r.Replace(s)
 
-	re := regexp.MustCompile(`[^0-9A-Za-z\\s.\_\-]+`)
+	re := regexp.MustCompile(`[^0-9A-Za-z.\_\-]+`)
 
 	return re.ReplaceAllString(s, "-")
 }


### PR DESCRIPTION
Here is the fix for issue https://github.com/hellt/cmdo/issues/23.
This replaces all spaces in the commands with a '-' in the filename. The regex incorrectly excluded whitespace, \s from the replacement.
The other trim command cleans the commands from the send-commands-from-file of leading or trailing whitespace. The send-command commands from inventory.yaml were and are not affected.